### PR TITLE
including es6 package d3-ease broke tests here and up the dep chain

### DIFF
--- a/karma.conf.dev.js
+++ b/karma.conf.dev.js
@@ -14,6 +14,8 @@ module.exports = function (config) {
     browsers: ["PhantomJS"],
     basePath: ".", // repository root.
     files: [
+      // es6 polyfill for phantom
+      "node_modules/babel-core/browser-polyfill.js",
       // Sinon has issues with webpack. Do global include.
       "node_modules/sinon/pkg/sinon.js",
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,6 +24,8 @@ module.exports = function (config) {
       "test/client/main.js": ["webpack"]
     },
     files: [
+      // es6 polyfill for phantom
+      "node_modules/babel-core/browser-polyfill.js",
       // Sinon has issues with webpack. Do global include.
       "node_modules/sinon/pkg/sinon.js",
 


### PR DESCRIPTION
cc/ @kenwheeler 

Including `victory-animation` in other repos was causing weird test failures.  I traced it back to `d3-ease`, and realized that it is published as non-transpiled es6. This PR adds an es6 polyfill for phantomjs
