### PR TITLE
Add lib in version hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,4 @@ coverage
 node_modules
 bower_components
 .tmp
-lib
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "homepage": "https://github.com/formidablelabs/victory-animation",
   "scripts": {
-    "postinstall": "npm run build-lib",
+    "prepublish": "npm run build-lib",
+    "postinstall": "node -e \"require('fs').stat('lib', function(e,s){process.exit(e || !s.isDirectory() ? 1 : 0)})\" || npm run build-lib",
     "preversion": "npm run check",
     "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,9 @@
   },
   "homepage": "https://github.com/formidablelabs/victory-animation",
   "scripts": {
-    "prepublish": "npm run build-lib",
     "postinstall": "node -e \"require('fs').stat('lib', function(e,s){process.exit(e || !s.isDirectory() ? 1 : 0)})\" || npm run build-lib",
     "preversion": "npm run check",
-    "version": "npm run clean && npm run build && git add -A dist",
+    "version": "npm run clean && npm run build && git add -A dist lib",
     "clean-dist": "rimraf dist",
     "build-dist-min": "webpack --config webpack.config.js",
     "build-dist-dev": "webpack --config webpack.config.dev.js",


### PR DESCRIPTION
...and check for lib first in postinstall hook, same as Radium.

(Aside: if we wanted to change to something easier on the eyes than the Node `stat` snippet, I came up with `cd lib/.. || npm run build-lib` which should have the same semantics + platform support, I believe.)

Fixes FormidableLabs/victory-bar#12

/cc @ryan-roemer @boygirl
