### PR TITLE
Check for lib before building in postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/formidablelabs/victory-animation",
   "scripts": {
-    "postinstall": "npm run build-lib",
+    "postinstall": "node -e \"require('fs').stat('lib', function(e,s){process.exit(e || !s.isDirectory() ? 1 : 0)})\" || npm run build-lib",
     "preversion": "npm run check",
     "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",


### PR DESCRIPTION
(Aside: if we wanted to change to something easier on the eyes than the Node `stat` snippet, I came up with `cd lib/.. || npm run build-lib` which should have the same semantics + platform support, I believe.)

Fixes FormidableLabs/victory-bar#12

/cc @ryan-roemer @boygirl
