### PR TITLE
Stop VictoryAnimation from creating NaNs and passing them down as props

### DIFF
--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -3,6 +3,25 @@
 import React from "react";
 import d3 from "d3";
 
+/**
+ * By default, `d3.interpolate` does not handle interpolation to or from null
+ * or undefined values in a nice way. They end up getting handled by
+ * `d3.interpolateNumber`, which tries to perform arithmetic on them, resulting
+ * in NaN. Without this custom interpolator, `VictoryAnimation` turns such values
+ * into NaNs and happily * passes them along as props to whatever component
+ * it's animating. The component will then warn that it received props with
+ * invalid types, since `typeof NaN === 'number'` and it was expecting either
+ * some other type or null or undefined.
+ */
+d3.interpolators.push(function (a, b) {
+  // If either value is null, go directly to the end value `b`.
+  if (a == null || b == null) {
+    return function () {
+      return b;
+    };
+  }
+});
+
 class VictoryAnimation extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -7,8 +7,8 @@ import d3 from "d3";
  * By default, `d3.interpolate` does not handle interpolation to or from null
  * or undefined values in a nice way. They end up getting handled by
  * `d3.interpolateNumber`, which tries to perform arithmetic on them, resulting
- * in NaN. Without this custom interpolator, `VictoryAnimation` turns such values
- * into NaNs and happily * passes them along as props to whatever component
+ * in NaN. Without this custom interpolator, `VictoryAnimation` turns such
+ * values into NaNs and happily passes them along as props to whatever component
  * it's animating. The component will then warn that it received props with
  * invalid types, since `typeof NaN === 'number'` and it was expecting either
  * some other type or null or undefined.

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -2,26 +2,9 @@
 
 import React from "react";
 import d3 from "d3";
+import { addVictoryInterpolator } from "../util";
 
-/**
- * By default, `d3.interpolate` turns null start/end values into 0 and undefined
- * values into NaN (because it tries to do arithmetic on them). Without this
- * custom interpolator, `VictoryAnimation` turns such values into 0s or NaNs
- * and happily passes them along as props to whatever component it's animating.
- * The component will then warn that it received props with invalid types,
- * since `typeof NaN === 'number'` and it was expecting either some other type,
- * or null or undefined. This custom interpolator prevents null from becoming
- * 0 and undefined becoming NaN. We can't assume that the wrapped component
- * accepts numerical values for whatever prop is being interpolated.
- */
-d3.interpolators.push(function (a, b) {
-  // If either value is null, go directly to the end value `b`.
-  if (a == null || b == null) {
-    return function () {
-      return b;
-    };
-  }
-});
+addVictoryInterpolator();
 
 class VictoryAnimation extends React.Component {
   constructor(props) {
@@ -90,7 +73,8 @@ class VictoryAnimation extends React.Component {
     */
     if (this.step >= 1) {
       this.step = 1;
-      this.setState(this.interpolator(this.step));
+      const newState = this.interpolator(this.step);
+      this.setState(newState);
       if (this.queue.length > 0) {
         cancelAnimationFrame(this.raf);
         this.queue.shift();
@@ -105,7 +89,9 @@ class VictoryAnimation extends React.Component {
       current step value that's transformed by the ease function to the
       interpolator, which is cached for performance whenever props are received
     */
-    this.setState(this.interpolator(this.ease(this.step)));
+    const easedStep = this.ease(this.step);
+    const newState = this.interpolator(easedStep);
+    this.setState(newState);
     /* increase step by velocity */
     this.step += this.props.velocity;
     /*

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -73,8 +73,7 @@ class VictoryAnimation extends React.Component {
     */
     if (this.step >= 1) {
       this.step = 1;
-      const newState = this.interpolator(this.step);
-      this.setState(newState);
+      this.setState(this.interpolator(this.step));
       if (this.queue.length > 0) {
         cancelAnimationFrame(this.raf);
         this.queue.shift();
@@ -89,9 +88,7 @@ class VictoryAnimation extends React.Component {
       current step value that's transformed by the ease function to the
       interpolator, which is cached for performance whenever props are received
     */
-    const easedStep = this.ease(this.step);
-    const newState = this.interpolator(easedStep);
-    this.setState(newState);
+    this.setState(this.interpolator(this.ease(this.step)));
     /* increase step by velocity */
     this.step += this.props.velocity;
     /*

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -4,14 +4,15 @@ import React from "react";
 import d3 from "d3";
 
 /**
- * By default, `d3.interpolate` does not handle interpolation to or from null
- * or undefined values in a nice way. They end up getting handled by
- * `d3.interpolateNumber`, which tries to perform arithmetic on them, resulting
- * in NaN. Without this custom interpolator, `VictoryAnimation` turns such
- * values into NaNs and happily passes them along as props to whatever component
- * it's animating. The component will then warn that it received props with
- * invalid types, since `typeof NaN === 'number'` and it was expecting either
- * some other type or null or undefined.
+ * By default, `d3.interpolate` turns null start/end values into 0 and undefined
+ * values into NaN (because it tries to do arithmetic on them). Without this
+ * custom interpolator, `VictoryAnimation` turns such values into 0s or NaNs
+ * and happily passes them along as props to whatever component it's animating.
+ * The component will then warn that it received props with invalid types,
+ * since `typeof NaN === 'number'` and it was expecting either some other type,
+ * or null or undefined. This custom interpolator prevents null from becoming
+ * 0 and undefined becoming NaN. We can't assume that the wrapped component
+ * accepts numerical values for whatever prop is being interpolated.
  */
 d3.interpolators.push(function (a, b) {
   // If either value is null, go directly to the end value `b`.

--- a/src/util.js
+++ b/src/util.js
@@ -25,8 +25,9 @@ let interpolatorAdded = false;
  */
 export const victoryInterpolator = function (a, b) {
   // If the values are strictly equal, or either value is null or undefined,
-  // just use the end value `b` at every step. The value will jump no matter
-  // what, but we can try to jump at a good time (like the halfway point).
+  // just use the start value `a` or end value `b` at every step, as there is
+  // no reasonable in-between value. The value will jump, but we can try to
+  // jump at a good time (like the halfway point).
   if (a === b || a == null || b == null) {
     return function (t) {
       // Switch to `b` halfway through the interpolation.

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,58 @@
+import d3 from "d3";
+
+let interpolatorAdded = false;
+
+/**
+ * By default, `d3.interpolate` (which cycles through a list of interpolators)
+ * has a few downsides:
+ *
+ * - `null` values get turned into 0.
+ * - `undefined`, `function`, and some other value types get turned into NaN.
+ * - It tries to interpolate between identical start->end values, doing
+ *   unnecessary calculations that sometimes result in floating point rounding
+ *   errors.
+ *
+ * If only the default interpolators are used, `VictoryAnimation` will happily
+ * pass down NaN (and other bad) values as props to the wrapped component.
+ * The component will then either use the incorrect values or complain that it
+ * was passed props of the incorrect type. This custom interpolator is added
+ * using the `d3.interpolators` API, and prevents such cases from happening
+ * for most values.
+ *
+ * @param {any} a - Start value.
+ * @param {any} b - End value.
+ * @returns {Function} Returns an interpolation function, if possible.
+ */
+export const victoryInterpolator = function (a, b) {
+  // If the values are strictly equal, or either value is null or undefined,
+  // just use the end value `b` at every step. The value will jump no matter
+  // what, but we can try to jump at a good time (like the halfway point).
+  if (a === b || a == null || b == null) {
+    return function (t) {
+      // Switch to `b` halfway through the interpolation.
+      return (t < 0.5) ? a : b;
+    };
+  }
+  if (typeof a === "function" || typeof b === "function") {
+    return function (t) {
+      // We're interpolating to or from a function. The interpolated value will
+      // be a function that calls `a` (if it's a function) and `b` (if it's a
+      // function) and calls `d3.interpolate` on the resulting values.
+      // Note that our function won't necessarily be called (that's up to the
+      // component) - but if it does get called, it will return an
+      // appropriately interpolated value.
+      return function () {
+        const aval = (typeof a === "function") ? a.apply(this, arguments) : a;
+        const bval = (typeof b === "function") ? b.apply(this, arguments) : b;
+        return d3.interpolate(aval, bval)(t);
+      };
+    };
+  }
+};
+
+export const addVictoryInterpolator = function () {
+  if (!interpolatorAdded) {
+    d3.interpolators.push(victoryInterpolator);
+    interpolatorAdded = true;
+  }
+};

--- a/test/client/spec/util.spec.js
+++ b/test/client/spec/util.spec.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-unused-expressions */
+import { victoryInterpolator } from "src/util";
+
+describe("victoryInterpolator", () => {
+  it("does not attempt to interpolate identical values", () => {
+    // This case fails with the default interpolator, returning *almost* 3.
+    expect(victoryInterpolator(3, 3)(0.25920000000000004)).to.equal(3);
+  });
+
+  it("switches from null at the halfway point", () => {
+    // This case fails with the default interpolator, returning *almost* 3.
+    const interpolator = victoryInterpolator(null, 5);
+    expect(interpolator(0)).to.be.null;
+    expect(interpolator(0.49)).to.be.null;
+    expect(interpolator(0.5)).to.equal(5);
+    expect(interpolator(1)).to.equal(5);
+  });
+
+  it("switches to null at the halfway point", () => {
+    // This case fails with the default interpolator, returning *almost* 3.
+    const interpolator = victoryInterpolator(5, null);
+    expect(interpolator(0)).to.equal(5);
+    expect(interpolator(0.49)).to.equal(5);
+    expect(interpolator(0.5)).to.be.null;
+    expect(interpolator(1)).to.be.null;
+  });
+
+  it("switches from undefined at the halfway point", () => {
+    // This case fails with the default interpolator, returning *almost* 3.
+    const interpolator = victoryInterpolator(undefined, 5);
+    expect(interpolator(0)).to.be.undefined;
+    expect(interpolator(0.49)).to.be.undefined;
+    expect(interpolator(0.5)).to.equal(5);
+    expect(interpolator(1)).to.equal(5);
+  });
+
+  it("switches to undefined at the halfway point", () => {
+    // This case fails with the default interpolator, returning *almost* 3.
+    const interpolator = victoryInterpolator(5, undefined);
+    expect(interpolator(0)).to.equal(5);
+    expect(interpolator(0.49)).to.equal(5);
+    expect(interpolator(0.5)).to.be.undefined;
+    expect(interpolator(1)).to.be.undefined;
+  });
+
+  it("interpolates functions", () => {
+    // This case fails with the default interpolator, returning *almost* 3.
+    const fromFn = () => 5;
+    const toFn = () => 10;
+    const interpolator = victoryInterpolator(fromFn, toFn);
+    const halfwayFn = interpolator(0.5);
+    expect(halfwayFn).to.be.a("function");
+    expect(halfwayFn()).to.equal(7.5);
+  });
+});


### PR DESCRIPTION
See comment! `d3.interpolate` does not handle null, undefined, or function values correctly, and this was causing VictoryAnimation to send NaN-valued props.

/cc @boygirl @colinmegill
