### PR TITLE
Improve victoryInterpolator to handle more cases

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -88,8 +88,8 @@ export const interpolateFunction = function (a, b) {
 };
 
 /**
- * By default, `d3.interpolate` (which then tries a list of interpolators) has
- * a few downsides:
+ * By default, the list of interpolators used by `d3.interpolate` have a few
+ * downsides:
  *
  * - `null` values get turned into 0.
  * - `undefined`, `function`, and some other value types get turned into NaN.

--- a/src/util.js
+++ b/src/util.js
@@ -2,7 +2,7 @@ import d3 from "d3";
 import _ from "lodash";
 
 export const isInterpolatable = function (obj) {
-  // d3 turns null into 0, which we don't want.
+  // d3 turns null into 0 and undefined into NaN, which we don't want.
   if (obj != null) {
     switch (typeof obj) {
       case "number":
@@ -17,9 +17,6 @@ export const isInterpolatable = function (obj) {
         // d3 turns Booleans into integers, which we don't want. Sure, we could
         // interpolate from 0 -> 1, but we'd be sending a non-Boolean to
         // something expecting a Boolean.
-        return false;
-      case "undefined":
-        // d3 turns undefined into NaN, which we don't want.
         return false;
       case "object":
         // Don't try to interpolate class instances (except Date or Array).
@@ -88,11 +85,13 @@ export const interpolateFunction = function (a, b) {
 };
 
 /**
- * By default, the list of interpolators used by `d3.interpolate` have a few
+ * By default, the list of interpolators used by `d3.interpolate` has a few
  * downsides:
  *
  * - `null` values get turned into 0.
  * - `undefined`, `function`, and some other value types get turned into NaN.
+ * - Boolean types get turned into numbers, which probably will be meaningless
+ *   to whatever is consuming them.
  * - It tries to interpolate between identical start and end values, doing
  *   unnecessary calculations that sometimes result in floating point rounding
  *   errors.

--- a/test/client/spec/util.spec.js
+++ b/test/client/spec/util.spec.js
@@ -7,38 +7,43 @@ describe("victoryInterpolator", () => {
     expect(victoryInterpolator(3, 3)(0.25920000000000004)).to.equal(3);
   });
 
-  it("switches from null at the halfway point", () => {
+  it("does not attempt to interpolate Boolean values", () => {
+    // The default interpolator would return 0.5.
+    expect(victoryInterpolator(false, true)(0.5)).to.equal(true);
+  });
+
+  it("always returns the end value if starting from null", () => {
     // This case fails with the default interpolator, returning *almost* 3.
     const interpolator = victoryInterpolator(null, 5);
-    expect(interpolator(0)).to.be.null;
-    expect(interpolator(0.49)).to.be.null;
+    expect(interpolator(0)).to.equal(5);
+    expect(interpolator(0.49)).to.equal(5);
     expect(interpolator(0.5)).to.equal(5);
     expect(interpolator(1)).to.equal(5);
   });
 
-  it("switches to null at the halfway point", () => {
+  it("always returns the end value if ending on null", () => {
     // This case fails with the default interpolator, returning *almost* 3.
     const interpolator = victoryInterpolator(5, null);
-    expect(interpolator(0)).to.equal(5);
-    expect(interpolator(0.49)).to.equal(5);
+    expect(interpolator(0)).to.be.null;
+    expect(interpolator(0.49)).to.be.null;
     expect(interpolator(0.5)).to.be.null;
     expect(interpolator(1)).to.be.null;
   });
 
-  it("switches from undefined at the halfway point", () => {
+  it("always returns the end value if starting from undefined", () => {
     // This case fails with the default interpolator, returning *almost* 3.
     const interpolator = victoryInterpolator(undefined, 5);
-    expect(interpolator(0)).to.be.undefined;
-    expect(interpolator(0.49)).to.be.undefined;
+    expect(interpolator(0)).to.equal(5);
+    expect(interpolator(0.49)).to.equal(5);
     expect(interpolator(0.5)).to.equal(5);
     expect(interpolator(1)).to.equal(5);
   });
 
-  it("switches to undefined at the halfway point", () => {
+  it("always returns the end value if ending on undefined", () => {
     // This case fails with the default interpolator, returning *almost* 3.
     const interpolator = victoryInterpolator(5, undefined);
-    expect(interpolator(0)).to.equal(5);
-    expect(interpolator(0.49)).to.equal(5);
+    expect(interpolator(0)).to.be.undefined;
+    expect(interpolator(0.49)).to.undefined;
     expect(interpolator(0.5)).to.be.undefined;
     expect(interpolator(1)).to.be.undefined;
   });


### PR DESCRIPTION
Prevent d3 from attempting to interpolate values that don't make sense to interpolate, like: Boolean, NaN, Infinity, arbitrary class instances, etc. Change interpolation of such values to immediately jump to the end value, to match d3's behavior, instead of jumping at the halfway point.

/cc @boygirl
