### PR TITLE
Cancel `this.raf` when component unmounts

### DIFF
--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -71,6 +71,11 @@ export default class VictoryAnimation extends React.Component {
       this.traverseQueue();
     }
   }
+  componentWillUnmount() {
+    if (this.raf) {
+      cancelAnimationFrame(this.raf);
+    }
+  }
   /* Traverse the tween queue */
   traverseQueue() {
     if (this.queue.length > 0) {


### PR DESCRIPTION
Fixes #18 

This is a quick one: on `componentWillUnmount`, it cancels `this.raf` (if there is any), which prevents the callback from attempting to set state on an unmounted component.

/cc @exogen @boygirl 
