### PR TITLE
Deduplicate requestAnimationFrame scheduling code

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -29,42 +29,62 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <button type="button" onClick={this.clickHandler}>Toggle X</button>
-        <VictoryAnimation data={
-          {
-            x: this.state.x,
-            w: this.state.w,
-            h: this.state.h,
-            color: this.state.color,
-            br: this.state.br,
-            rotate: this.state.rotate
-          }}
-        >
-          {(data) => {
-            return (
-              <div style={
-                {
-                  position: "relative",
-                  left: data.x,
-                  width: data.w,
-                  height: data.h,
-                  backgroundColor: data.color,
-                  color: "white",
-                  fontFamily: "Lucida Grande",
-                  padding: 40,
-                  borderRadius: data.br,
-                  textAlign: "center",
-                  alignItems: "center",
-                  display: "flex",
-                  fontSize: 40,
-                  transform: `rotate(${data.rotate}deg)`
-                }}
+        <div style={{ float: "left", width: 520, height: 520 }}>
+          <button type="button" onClick={this.clickHandler}>Toggle X</button>
+          <VictoryAnimation data={
+            {
+              x: this.state.x,
+              w: this.state.w,
+              h: this.state.h,
+              color: this.state.color,
+              br: this.state.br,
+              rotate: this.state.rotate
+            }}
+          >
+            {(data) => {
+              return (
+                <div style={
+                  {
+                    position: "relative",
+                    left: data.x,
+                    width: data.w,
+                    height: data.h,
+                    backgroundColor: data.color,
+                    color: "white",
+                    fontFamily: "Lucida Grande",
+                    padding: 40,
+                    borderRadius: data.br,
+                    textAlign: "center",
+                    alignItems: "center",
+                    display: "flex",
+                    fontSize: 40,
+                    transform: `rotate(${data.rotate}deg)`
+                  }}
+                >
+                  <div style={{textAlign: "center", width: "100%"}}>Test</div>
+                </div>
+              );
+            }}
+          </VictoryAnimation>
+        </div>
+        <div style={{ float: "left" }}>
+          <VictoryAnimation data={[
+            { background: "red" },
+            { background: "green" },
+            { background: "blue" } ]}
+            delay={500}
+          >
+            {(style) => (
+              <div style={{
+                  width: 100,
+                  height: 100,
+                  borderRadius: 50,
+                  ...style }}
               >
-                <div style={{textAlign: "center", width: "100%"}}>Test</div>
               </div>
-            );
-          }}
-        </VictoryAnimation>
+            )}
+          </VictoryAnimation>
+        </div>
       </div>
     );
   }

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -76,10 +76,10 @@ class App extends React.Component {
           >
             {(style) => (
               <div style={{
-                  width: 100,
-                  height: 100,
-                  borderRadius: 50,
-                  ...style }}
+                width: 100,
+                height: 100,
+                borderRadius: 50,
+                ...style }}
               >
               </div>
             )}

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -1,4 +1,4 @@
-/*global requestAnimationFrame, cancelAnimationFrame, setTimeout*/
+/*global requestAnimationFrame, cancelAnimationFrame, setTimeout, clearTimeout*/
 
 import React from "react";
 import d3 from "d3";
@@ -33,11 +33,12 @@ export default class VictoryAnimation extends React.Component {
   constructor(props) {
     super(props);
     /* defaults */
-    this.state = Array.isArray(this.props.data)
-      ? this.props.data[0] : this.props.data;
+    this.state = Array.isArray(this.props.data) ?
+      this.props.data[0] : this.props.data;
     this.interpolator = null;
     this.step = 0;
-    this.queue = [];
+    this.queue = Array.isArray(this.props.data) ?
+      this.props.data.slice(1) : [];
     /* build easing function */
     this.ease = d3.ease(this.props.easing);
     /*
@@ -46,35 +47,40 @@ export default class VictoryAnimation extends React.Component {
     */
     this.functionToBeRunEachFrame = this.functionToBeRunEachFrame.bind(this);
   }
+  componentDidMount() {
+    if (this.queue.length) {
+      this.traverseQueue();
+    }
+  }
   /* lifecycle */
   componentWillReceiveProps(nextProps) {
     /* cancel existing loop if it exists */
     if (this.raf) {
       cancelAnimationFrame(this.raf);
     }
-    /* If an object was supplied */
-    if (Array.isArray(nextProps.data) === false) {
-      /* compare cached version to next props */
-      this.interpolator = d3.interpolate(this.state, nextProps.data);
-      /* reset step to zero */
-      this.step = 0;
-      /* start request animation frame */
-      setTimeout(() => {
-        this.raf = this.functionToBeRunEachFrame();
-      }, this.props.delay);
-    /* If an array was supplied */
-    } else {
-      /* Build our tween queue */
-      nextProps.data.forEach((data) => {
-        this.queue.push(data);
-      });
-      /* Start traversing the tween queue */
-      this.traverseQueue();
+    if (this.delayTimeout) {
+      clearTimeout(this.delayTimeout);
     }
+    /* If an array was supplied */
+    if (Array.isArray(nextProps.data)) {
+      /* Extend the tween queue */
+      this.queue.push(...nextProps.data);
+    /* If an object was supplied */
+    } else {
+      // Replace the tween queue. Could set `this.queue = [nextProps.data]`,
+      // but let's reuse the same array.
+      this.queue.length = 0;
+      this.queue.push(nextProps.data);
+    }
+    /* Start traversing the tween queue */
+    this.traverseQueue();
   }
   componentWillUnmount() {
     if (this.raf) {
       cancelAnimationFrame(this.raf);
+    }
+    if (this.delayTimeout) {
+      clearTimeout(this.delayTimeout);
     }
   }
   /* Traverse the tween queue */
@@ -86,7 +92,7 @@ export default class VictoryAnimation extends React.Component {
       this.interpolator = d3.interpolate(this.state, data);
       /* reset step to zero */
       this.step = 0;
-      setTimeout(() => {
+      this.delayTimeout = setTimeout(() => {
         this.raf = this.functionToBeRunEachFrame();
       }, this.props.delay);
     } else if (this.props.onEnd) {

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -61,16 +61,16 @@ export default class VictoryAnimation extends React.Component {
     if (this.delayTimeout) {
       clearTimeout(this.delayTimeout);
     }
-    /* If an array was supplied */
-    if (Array.isArray(nextProps.data)) {
-      /* Extend the tween queue */
-      this.queue.push(...nextProps.data);
     /* If an object was supplied */
-    } else {
+    if (!Array.isArray(nextProps.data)) {
       // Replace the tween queue. Could set `this.queue = [nextProps.data]`,
       // but let's reuse the same array.
       this.queue.length = 0;
       this.queue.push(nextProps.data);
+    /* If an array was supplied */
+    } else {
+      /* Extend the tween queue */
+      this.queue.push(...nextProps.data);
     }
     /* Start traversing the tween queue */
     this.traverseQueue();


### PR DESCRIPTION
This unifies handling of array vs. object in the `data` prop. Code for setting up the animation was duplicated. This takes advantage of the fact that we do nearly the same thing in both cases: if `data` is an array, extend the animation queue, if it's an object, replace the animation queue with `data`.

It also fixes a couple things:
- If the initial `data` value is an array, then upon mount we'll start animating beyond the first value, instead of ignoring the provided queue.
- Save a handle to the `setTimeout` that controls our delay, because we'll need to cancel it when new data comes in or we unmount.

Also adds a new demo of `data` array handling behavior.

/cc @kenwheeler @boygirl
