### PR TITLE
Use builder victory archetype

### DIFF
--- a/.builderrc
+++ b/.builderrc
@@ -1,3 +1,3 @@
 ---
 archetypes:
-  - builder-react-component
+  - builder-victory-component

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,14 @@ branches:
   only:
     - master
 
-env:
-  matrix:
-    - NPM_3=true
-    - NPM_3=false
-
 before_install:
   # GUI for real browsers.
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
-  # Potentially update to npm 3
-  - 'if [ "$NPM_3" = true ]; then npm install -g npm@3; else true; fi'
+  # Install npmv3 because of postinstall bugs in npmv2:
+  # See https://github.com/FormidableLabs/victory/issues/98
+  - npm install -g npm@3
 
 script:
   - npm --version

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/formidablelabs/victory-animation",
   "scripts": {
-    "postinstall": "builder run npm:postinstall",
+    "postinstall": "cd lib || builder run npm:postinstall",
     "preversion": "builder run npm:preversion",
     "version": "builder run npm:version",
     "test": "builder run npm:test"

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "test": "builder run npm:test"
   },
   "dependencies": {
-    "builder": "~2.1.3",
-    "builder-victory-component": "~0.0.4",
+    "builder": "~2.2.2",
+    "builder-victory-component": "~0.0.5",
     "d3": "^3.5.8"
   },
   "devDependencies": {
-    "builder-victory-component-dev": "~0.0.4",
+    "builder-victory-component-dev": "~0.0.5",
     "chai": "^3.2.0",
     "mocha": "^2.3.3",
     "react": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,11 @@
   },
   "dependencies": {
     "builder": "~2.1.3",
-    "builder-react-component": "~0.1.0",
-    "d3": "^3.5.8",
-    "lodash": "^3.10.1",
-    "radium": "^0.14.3"
+    "builder-victory-component": "~0.0.4",
+    "d3": "^3.5.8"
   },
   "devDependencies": {
-    "builder-react-component-dev": "~0.1.0",
+    "builder-victory-component-dev": "~0.0.4",
     "chai": "^3.2.0",
     "mocha": "^2.3.3",
     "react": "^0.14.0",


### PR DESCRIPTION
- Removes archetype-provided dependencies
- Makes component `npm install` safe using `npmv2`
