### PR TITLE
use d3-modules, add easing prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "builder": "~2.2.2",
     "builder-victory-component": "~0.0.5",
-    "d3": "^3.5.8"
+    "d3-ease": "^0.3.0",
+    "d3-interpolate": "^0.2.0"
   },
   "devDependencies": {
     "builder-victory-component-dev": "~0.0.5",

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -1,7 +1,8 @@
 /*global requestAnimationFrame, cancelAnimationFrame, setTimeout*/
 
 import React from "react";
-import d3 from "d3";
+import d3Ease from "d3-ease";
+import d3Interpolate from "d3-interpolate";
 import { addVictoryInterpolator } from "../util";
 
 addVictoryInterpolator();
@@ -10,7 +11,18 @@ export default class VictoryAnimation extends React.Component {
   static propTypes = {
     children: React.PropTypes.func,
     velocity: React.PropTypes.number,
-    easing: React.PropTypes.string,
+    easing: React.PropTypes.oneOf([
+      "back", "backIn", "backOut", "backInOut",
+      "bounce", "bounceIn", "bounceOut", "bounceInOut",
+      "circle", "circleIn", "circleOut", "circleInOut",
+      "linear", "linearIn", "linearOut", "linearInOut",
+      "cubic", "cubicIn", "cubicOut", "cubicInOut",
+      "elastic", "elasticIn", "elasticOut", "elasticInOut",
+      "exp", "expIn", "expOut", "expInOut",
+      "poly", "polyIn", "polyOut", "polyInOut",
+      "quad", "quadIn", "quadOut", "quadInOut",
+      "sin", "sinIn", "sinOut", "sinInOut"
+    ]),
     delay: React.PropTypes.number,
     onEnd: React.PropTypes.func,
     data: React.PropTypes.oneOfType([
@@ -23,7 +35,7 @@ export default class VictoryAnimation extends React.Component {
     /* velocity modifies step each frame */
     velocity: 0.02,
     /* easing modifies step each frame */
-    easing: "quad-in-out",
+    easing: "quadInOut",
     /* delay between transitions */
     delay: 0,
     /* we got nothin' */
@@ -39,7 +51,7 @@ export default class VictoryAnimation extends React.Component {
     this.step = 0;
     this.queue = [];
     /* build easing function */
-    this.ease = d3.ease(this.props.easing);
+    this.ease = d3Ease[this.props.easing];
     /*
       unlike React.createClass({}), there is no autobinding of this in ES6 classes
       so we bind functionToBeRunEachFrame to current instance of victory animation class
@@ -55,7 +67,7 @@ export default class VictoryAnimation extends React.Component {
     /* If an object was supplied */
     if (Array.isArray(nextProps.data) === false) {
       /* compare cached version to next props */
-      this.interpolator = d3.interpolate(this.state, nextProps.data);
+      this.interpolator = d3Interpolate.value(this.state, nextProps.data);
       /* reset step to zero */
       this.step = 0;
       /* start request animation frame */
@@ -83,7 +95,7 @@ export default class VictoryAnimation extends React.Component {
       /* Get the next index */
       const data = this.queue[0];
       /* compare cached version to next props */
-      this.interpolator = d3.interpolate(this.state, data);
+      this.interpolator = d3Interpolate.value(this.state, data);
       /* reset step to zero */
       this.step = 0;
       setTimeout(() => {

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,5 @@
-import d3 from "d3";
 import _ from "lodash";
+import d3Interpolate from "d3-interpolate";
 
 export const isInterpolatable = function (obj) {
   // d3 turns null into 0 and undefined into NaN, which we don't want.
@@ -82,7 +82,7 @@ export const interpolateFunction = function (a, b) {
       /* eslint-disable no-invalid-this */
       const aval = (typeof a === "function") ? a.apply(this, arguments) : a;
       const bval = (typeof b === "function") ? b.apply(this, arguments) : b;
-      return d3.interpolate(aval, bval)(t);
+      return d3Interpolate.value(aval, bval)(t);
     };
   };
 };
@@ -126,7 +126,7 @@ let interpolatorAdded = false;
 
 export const addVictoryInterpolator = function () {
   if (!interpolatorAdded) {
-    d3.interpolators.push(victoryInterpolator);
+    d3Interpolate.values.push(victoryInterpolator);
     interpolatorAdded = true;
   }
 };


### PR DESCRIPTION
cc/ @kenwheeler 

this PR switches from using all of d3 to just using d3-interpolate and d3-ease. It also adds all the accepted easing options to prop types. 
