### PR TITLE
Use d3-timer instead of manual requestAnimationFrame

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "stage": 0,
-  "nonStandard": true
+  "nonStandard": true,
+  "breakConfig": true
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "builder": "~2.2.2",
     "builder-victory-component": "~0.0.5",
     "d3-ease": "^0.3.0",
-    "d3-interpolate": "^0.2.0"
+    "d3-interpolate": "^0.2.0",
+    "d3-timer": "^0.0.6"
   },
   "devDependencies": {
     "builder-victory-component-dev": "~0.0.5",

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -3,7 +3,10 @@
 import React from "react";
 import d3Ease from "d3-ease";
 import d3Interpolate from "d3-interpolate";
+import { timer } from "d3-timer";
 import { addVictoryInterpolator } from "../util";
+
+const VELOCITY_MULTIPLIER = 16.5;
 
 addVictoryInterpolator();
 
@@ -48,7 +51,6 @@ export default class VictoryAnimation extends React.Component {
     this.state = Array.isArray(this.props.data) ?
       this.props.data[0] : this.props.data;
     this.interpolator = null;
-    this.step = 0;
     this.queue = Array.isArray(this.props.data) ?
       this.props.data.slice(1) : [];
     /* build easing function */
@@ -60,6 +62,7 @@ export default class VictoryAnimation extends React.Component {
     this.functionToBeRunEachFrame = this.functionToBeRunEachFrame.bind(this);
   }
   componentDidMount() {
+    // Length check prevents us from triggering `onEnd` in `traverseQueue`.
     if (this.queue.length) {
       this.traverseQueue();
     }
@@ -67,11 +70,8 @@ export default class VictoryAnimation extends React.Component {
   /* lifecycle */
   componentWillReceiveProps(nextProps) {
     /* cancel existing loop if it exists */
-    if (this.raf) {
-      cancelAnimationFrame(this.raf);
-    }
-    if (this.delayTimeout) {
-      clearTimeout(this.delayTimeout);
+    if (this.timer) {
+      this.timer.stop();
     }
     /* If an object was supplied */
     if (!Array.isArray(nextProps.data)) {
@@ -88,60 +88,44 @@ export default class VictoryAnimation extends React.Component {
     this.traverseQueue();
   }
   componentWillUnmount() {
-    if (this.raf) {
-      cancelAnimationFrame(this.raf);
-    }
-    if (this.delayTimeout) {
-      clearTimeout(this.delayTimeout);
+    if (this.timer) {
+      this.timer.stop();
     }
   }
   /* Traverse the tween queue */
   traverseQueue() {
-    if (this.queue.length > 0) {
+    if (this.queue.length) {
       /* Get the next index */
       const data = this.queue[0];
       /* compare cached version to next props */
       this.interpolator = d3Interpolate.value(this.state, data);
       /* reset step to zero */
-      this.step = 0;
-      this.delayTimeout = setTimeout(() => {
-        this.raf = this.functionToBeRunEachFrame();
-      }, this.props.delay);
+      this.timer = timer(this.functionToBeRunEachFrame, this.props.delay);
     } else if (this.props.onEnd) {
       this.props.onEnd();
     }
   }
   /* every frame we... */
-  functionToBeRunEachFrame() {
+  functionToBeRunEachFrame(elapsed) {
     /*
       step can generate imprecise values, sometimes greater than 1
-      if this happens set the state to 1 and return, cancelling the loop
+      if this happens set the state to 1 and return, cancelling the timer
     */
-    if (this.step >= 1) {
-      this.step = 1;
-      this.setState(this.interpolator(this.step));
-      if (this.queue.length > 0) {
-        cancelAnimationFrame(this.raf);
-        this.queue.shift();
-        this.traverseQueue();
-      } else if (this.props.onEnd) {
-        this.props.onEnd();
-      }
+    const step = elapsed / (VELOCITY_MULTIPLIER / this.props.velocity);
+
+    if (step >= 1) {
+      this.setState(this.interpolator(1));
+      this.timer.stop();
+      this.queue.shift();
+      this.traverseQueue(); // Will take care of calling `onEnd`.
       return;
     }
     /*
-      if we're not at the end of the loop, set the state by passing
+      if we're not at the end of the timer, set the state by passing
       current step value that's transformed by the ease function to the
       interpolator, which is cached for performance whenever props are received
     */
-    this.setState(this.interpolator(this.ease(this.step)));
-    /* increase step by velocity */
-    this.step += this.props.velocity;
-    /*
-      requestAnimationFrame calls a function on a frame.
-      continue the loop by feeding functionToBeRunEachFrame
-    */
-    this.raf = requestAnimationFrame(this.functionToBeRunEachFrame);
+    this.setState(this.interpolator(this.ease(step)));
   }
   render() {
     return this.props.children(this.state);

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -1,5 +1,3 @@
-/*global requestAnimationFrame, cancelAnimationFrame, setTimeout, clearTimeout*/
-
 import React from "react";
 import d3Ease from "d3-ease";
 import d3Interpolate from "d3-interpolate";

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -12,8 +12,8 @@ import { addVictoryInterpolator } from "../util";
 // velocity each frame. But for now we still support velocity as we have code
 // using it. Since we use `d3-timer` now and it's duration-based, choose a
 // velocity multiplier here that just happens to result in animations going
-// approximately the same speed (on reasonably fast systems).
-const VELOCITY_MULTIPLIER = 16.5;
+// approximately the same speed on systems getting around 60 fps.
+const VELOCITY_MULTIPLIER = 16.5; // ~ 1 / 60
 
 addVictoryInterpolator();
 

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -4,6 +4,15 @@ import d3Interpolate from "d3-interpolate";
 import { timer } from "d3-timer";
 import { addVictoryInterpolator } from "../util";
 
+// Nearly all animation libraries are duration-based, not velocity-based.
+// In other words, you say "I want the animation to take this long", not
+// "I want things to move this fast". Using velocity will make the animation
+// take different amounts of time in computers of different speed, since
+// they'll have a different framerate but still adjust values by the same
+// velocity each frame. But for now we still support velocity as we have code
+// using it. Since we use `d3-timer` now and it's duration-based, choose a
+// velocity multiplier here that just happens to result in animations going
+// the same speed (on reasonably fast systems).
 const VELOCITY_MULTIPLIER = 16.5;
 
 addVictoryInterpolator();

--- a/src/components/victory-animation.jsx
+++ b/src/components/victory-animation.jsx
@@ -7,12 +7,12 @@ import { addVictoryInterpolator } from "../util";
 // Nearly all animation libraries are duration-based, not velocity-based.
 // In other words, you say "I want the animation to take this long", not
 // "I want things to move this fast". Using velocity will make the animation
-// take different amounts of time in computers of different speed, since
+// take different amounts of time on computers of different speed, since
 // they'll have a different framerate but still adjust values by the same
 // velocity each frame. But for now we still support velocity as we have code
 // using it. Since we use `d3-timer` now and it's duration-based, choose a
 // velocity multiplier here that just happens to result in animations going
-// the same speed (on reasonably fast systems).
+// approximately the same speed (on reasonably fast systems).
 const VELOCITY_MULTIPLIER = 16.5;
 
 addVictoryInterpolator();


### PR DESCRIPTION
Difference from Guy's PR: this is based on the merge of our dedupe, and fixes the case where we have multiple items in the queue and/or have an `onEnd`.

Totally unrelated change, but might as well get it in: use `breakConfig` in `.babelrc`.

/cc @boygirl @guykr-stratoscale

TODO: Add Guy to a `CONTRIBUTORS` file/section somewhere? We have none at the moment.
